### PR TITLE
Add config flow strings to translations

### DIFF
--- a/custom_components/sessy/strings.json
+++ b/custom_components/sessy/strings.json
@@ -13,9 +13,6 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "entity": {

--- a/custom_components/sessy/translations/en.json
+++ b/custom_components/sessy/translations/en.json
@@ -3,19 +3,16 @@
     "step": {
       "user": {
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "host": "[%key:common::config_flow::data::host%]"
+          "username": "Username",
+          "password": "Password",
+          "host": "Host"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     }
   },
   "entity": {

--- a/custom_components/sessy/translations/nl.json
+++ b/custom_components/sessy/translations/nl.json
@@ -3,19 +3,16 @@
     "step": {
       "user": {
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "host": "[%key:common::config_flow::data::host%]"
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord",
+          "host": "Host"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "cannot_connect": "Kan geen verbinding maken",
+      "invalid_auth": "Ongeldige gebruikersnaam en/of wachtwoord",
+      "unknown": "Onbekende fout"
     }
   },
   "entity": {


### PR DESCRIPTION
Custom components cannnot access core translation keys. Strings have now been added explicitly to translation files instead of relying on lookups.
Fix #24