### PR TITLE
Ensure config_flow has unique_id set

### DIFF
--- a/custom_components/sessy/__init__.py
+++ b/custom_components/sessy/__init__.py
@@ -27,6 +27,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = {}
 
+    hass.data[DOMAIN][config_entry.entry_id][SERIAL_NUMBER] = config_entry.data.get(CONF_USERNAME).upper()
+    
+    # Prevent duplicate entries in older setups
+    if not config_entry.unique_id:
+        config_entry.unique_id = hass.data[DOMAIN][config_entry.entry_id][SERIAL_NUMBER]
+
+
     _LOGGER.debug(f"Connecting to Sessy device at {config_entry.data.get(CONF_HOST)}")
     try:
         device = await get_sessy_device(
@@ -47,9 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     else:
         _LOGGER.info(f"Connection to {device.__class__} at {device.host} successful")
 
-    hass.data[DOMAIN][config_entry.entry_id][SERIAL_NUMBER] = config_entry.data.get(CONF_USERNAME).upper()
     hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE] = device
-
 
     # Generate Device Info
     hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE_INFO] = await generate_device_info(hass, config_entry, device)

--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -81,6 +81,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=data_schema
             )
 
+        await self.async_set_unique_id(user_input.get(CONF_USERNAME))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: user_input.get(CONF_HOST)})
+
         errors = {}
 
         # Attempt to connect to Sessy API
@@ -124,7 +127,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Check for duplicates
             await self.async_set_unique_id(serial_number)
-            self._abort_if_unique_id_configured(updates={CONF_HOST: local_name})
+            self._abort_if_unique_id_configured()
 
             # Update the config flow title
             self._name = local_name.removesuffix(".local")

--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -124,7 +124,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Check for duplicates
             await self.async_set_unique_id(serial_number)
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(updates={CONF_HOST: local_name})
 
             # Update the config flow title
             self._name = local_name.removesuffix(".local")

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.0.10"],
-  "version": "0.3.2",
+  "version": "0.3.3",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]


### PR DESCRIPTION
Fixes #45 
This patch updates will update existing config entries to with their unique_id to the serial number (which is also the username, for now) to prevent this