### PR TITLE
Add enabled_time config entities and suggested units

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 Home Assistant integration for Sessy home battery system.
 
 Currently supported:
-- Connect to Battery or P1 Dongle
-- Power Status sensors
+- Autodiscovery
+- Connect to Battery and/or P1 Dongle
+- Battery status sensors
+- Battery charge/discharge sensors
 - Set power strategy (select entity)
 - Set power setpoint (number entity)
-- Wifi RSSI sensor (Battery only)
-- P1 Status sensors (P1 Dongle only)
+- Wifi RSSI sensor
+- P1 Grid Status sensors (P1 Dongle only)
 - Firmware updates
 - Change configuration (min/max power)
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ TODO:
 - [X] Add Device Registry information
 - [X] Add logo to home-assistant/brands
 - [X] Add HACS configuration
-- [ ] Add Energy sensors
 - [ ] Add to HACS Default repository
+- [ ] Add Energy sensors
 
 Installation
 ============
@@ -32,7 +32,9 @@ HACS
 ----
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 
-Add this repository to HACS via the Custom Repositories options
+Add this repository to HACS via the Custom Repositories options.
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=PimDoos&category=integration&repository=ha-sessy)
 
 Manual
 ------
@@ -46,7 +48,9 @@ Add Sessy via the Integrations menu:
 
   [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=sessy)
 
-- Enter the IP address (preferably static) or hostname and the local username and password for the device you want to add
+- Discovered Sessy devices will be shown in the list. Alternatively, enter the hostname (sessy-xxxx.local) manually.
+
+- Enter the local username and password found on the sticker on the device
 
 - The integration will discover the device type and add it to Home Assistant
 

--- a/custom_components/sessy/__init__.py
+++ b/custom_components/sessy/__init__.py
@@ -18,7 +18,7 @@ from .util import clear_cache_command, generate_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.UPDATE]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.TIME, Platform.UPDATE]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.0.10"],
-  "version": "0.3.3",
+  "version": "0.4.0",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]

--- a/custom_components/sessy/number.py
+++ b/custom_components/sessy/number.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             SessyNumber(hass, config_entry, "Minimum Power",
                         SessyApiCommand.SYSTEM_SETTINGS, "min_power",
                         SessyApiCommand.SYSTEM_SETTINGS, "min_power",
-                        NumberDeviceClass.POWER, UnitOfPower.WATT, 0, 2200,
+                        NumberDeviceClass.POWER, UnitOfPower.WATT, 50, 2000,
                         entity_category=EntityCategory.CONFIG,
                         action_function=partial_update_settings)
             
@@ -52,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             SessyNumber(hass, config_entry, "Maximum Power",
                         SessyApiCommand.SYSTEM_SETTINGS, "max_power",
                         SessyApiCommand.SYSTEM_SETTINGS, "max_power",
-                        NumberDeviceClass.POWER, UnitOfPower.WATT, 0, 2200,
+                        NumberDeviceClass.POWER, UnitOfPower.WATT, 50, 2200,
                         entity_category=EntityCategory.CONFIG,
                         action_function=partial_update_settings)
             

--- a/custom_components/sessy/sensor.py
+++ b/custom_components/sessy/sensor.py
@@ -94,12 +94,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             sensors.append(
                 SessySensor(hass, config_entry, f"Renewable Energy Phase { phase_id } Voltage",
                             SessyApiCommand.POWER_STATUS, f"renewable_energy_phase{ phase_id }.voltage_rms",
-                            SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, UnitOfElectricPotential.MILLIVOLT)
+                            SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, UnitOfElectricPotential.MILLIVOLT,
+                            suggested_unit_of_measurement=UnitOfElectricPotential.VOLT)
             )
             sensors.append(
                 SessySensor(hass, config_entry, f"Renewable Energy Phase { phase_id } Current",
                             SessyApiCommand.POWER_STATUS, f"renewable_energy_phase{ phase_id }.current_rms",
-                            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, UnitOfElectricCurrent.MILLIAMPERE)
+                            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, UnitOfElectricCurrent.MILLIAMPERE,
+                            suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE)
             )
             sensors.append(
                 SessySensor(hass, config_entry, f"Renewable Energy Phase { phase_id } Power",
@@ -147,7 +149,7 @@ class SessySensor(SessyEntity, SensorEntity):
                  cache_command: SessyApiCommand, cache_key,
                  device_class: SensorDeviceClass = None, state_class: SensorStateClass = None, unit_of_measurement = None,
                  transform_function: function = None, translation_key: str = None,
-                 options = None, entity_category: EntityCategory = None, precision: int = None):
+                 options = None, entity_category: EntityCategory = None, precision: int = None, suggested_unit_of_measurement = None):
 
         super().__init__(hass=hass, config_entry=config_entry, name=name,
                        cache_command=cache_command, cache_key=cache_key,
@@ -159,6 +161,7 @@ class SessySensor(SessyEntity, SensorEntity):
         self._attr_entity_category = entity_category
 
         self._attr_suggested_display_precision = precision
+        self._attr_suggested_unit_of_measurement = suggested_unit_of_measurement
 
         self._attr_options = options
 

--- a/custom_components/sessy/time.py
+++ b/custom_components/sessy/time.py
@@ -1,0 +1,101 @@
+"""Time entities to control Sessy"""
+from __future__ import annotations
+from datetime import time
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfPower
+)
+from homeassistant.components.time import TimeEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+from sessypy.const import SessyApiCommand
+from sessypy.devices import SessyBattery, SessyDevice
+
+
+from .const import DOMAIN, SESSY_DEVICE, SCAN_INTERVAL_POWER, DEFAULT_SCAN_INTERVAL
+from .util import add_cache_command, start_time_from_string, stop_time_from_string, time_from_string, trigger_cache_update
+from .sessyentity import SessyEntity
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
+    """Set up the Sessy time entities"""
+
+    device = hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE]
+    times = []
+
+    if isinstance(device, SessyBattery):
+        await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_SETTINGS, DEFAULT_SCAN_INTERVAL)
+        
+        async def partial_update_enabled_time(start_time: time = None, stop_time: time = None) -> str:
+            settings: dict = await device.get_system_settings()
+            settings_enabled_time = settings.get("enabled_time").split("-")
+
+            if not start_time:
+                start_time = time_from_string(settings_enabled_time[0])
+
+            if not stop_time:
+                stop_time = time_from_string(settings_enabled_time[1])
+
+            settings_enabled_time = f"{start_time.strftime('%H:%M')}-{stop_time.strftime('%H:%M')}"
+            settings["enabled_time"] = settings_enabled_time
+            return settings
+        
+        async def update_start_time(key, value: time):
+            return await partial_update_enabled_time(start_time = value)
+        
+        async def update_stop_time(key, value: time):
+            return await partial_update_enabled_time(stop_time = value)
+        
+        times.append(
+            SessyTime(hass, config_entry, "Start Time",
+                        SessyApiCommand.SYSTEM_SETTINGS, "enabled_time",
+                        SessyApiCommand.SYSTEM_SETTINGS, "enabled_time",
+                        entity_category=EntityCategory.CONFIG,
+                        action_function=update_start_time,
+                        transform_function=start_time_from_string)
+            
+        ),
+        times.append(
+            SessyTime(hass, config_entry, "Stop Time",
+                        SessyApiCommand.SYSTEM_SETTINGS, "enabled_time",
+                        SessyApiCommand.SYSTEM_SETTINGS, "enabled_time",
+                        entity_category=EntityCategory.CONFIG,
+                        action_function=update_stop_time,
+                        transform_function=stop_time_from_string)
+            
+        )
+
+    async_add_entities(times)
+    
+class SessyTime(SessyEntity, TimeEntity):
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, name: str,
+                 cache_command: SessyApiCommand, cache_key,
+                 action_command: SessyApiCommand, action_key: SessyApiCommand,
+                 entity_category: EntityCategory = None,
+                 transform_function: function = None, action_function: function = None):
+        
+        super().__init__(hass=hass, config_entry=config_entry, name=name, 
+                       cache_command=cache_command, cache_key=cache_key, 
+                       transform_function=transform_function)
+
+        self._attr_entity_category = entity_category
+        
+        self.action_command = action_command
+        self.action_key = action_key
+        self.action_function: function = action_function
+    
+    def update_from_cache(self):
+        self._attr_available = self.cache_value != None
+        self._attr_native_value = self.cache_value
+        
+    async def async_set_value(self, value: time):
+        device: SessyDevice = self.hass.data[DOMAIN][self.config_entry.entry_id][SESSY_DEVICE]
+        
+        if not self.action_function:
+            payload = {self.action_key: str(value)}
+        else:
+            payload = await self.action_function(self.action_key, value)
+            
+        await device.api.post(self.action_command, payload)
+        await trigger_cache_update(self.hass, self.config_entry, self.cache_command)

--- a/custom_components/sessy/util.py
+++ b/custom_components/sessy/util.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from enum import Enum
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -74,6 +74,16 @@ def only_negative_as_positive(input: int) -> int:
 
 def only_positive(input: int) -> int:
     return max(input, 0)
+
+def time_from_string(input: str) -> time:
+    return datetime.strptime(input, "%H:%M").time()
+
+def start_time_from_string(input: str) -> time:
+    return time_from_string(input.split("-")[0])
+
+def stop_time_from_string(input: str) -> time:
+    return time_from_string(input.split("-")[1])
+
 
 def enum_to_options_list(options: Enum, transform_function: function = None) -> list[str]:
     output = list()


### PR DESCRIPTION
Close #7 
- Add enabled_time entities via time platform
- Add suggested unit to renewable sensors
- Update min/max power ranges