### PR TITLE
Add OTA All, Add scan_interval option flow

### DIFF
--- a/custom_components/sessy/button.py
+++ b/custom_components/sessy/button.py
@@ -23,7 +23,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     device: SessyDevice = hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE]
     buttons = []
 
-    await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_INFO, DEFAULT_SCAN_INTERVAL)
     buttons.append(
         SessyButton(hass, config_entry, "Dongle Restart",
                     SessyApiCommand.SYSTEM_INFO, 'status', device.restart,

--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -15,14 +15,15 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_HOST,
-    CONF_NAME
+    CONF_NAME,
+    CONF_SCAN_INTERVAL
 )
 from homeassistant.helpers import device_registry as dr
 
 from sessypy.devices import get_sessy_device, SessyBattery, SessyP1Meter
 from sessypy.util import SessyConnectionException, SessyLoginException
 
-from .const import DOMAIN
+from .const import DEFAULT_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_POWER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,7 +141,39 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             # Prompt user for the password
             return await self.async_step_user()
+        
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create the options flow."""
+        return OptionsFlowHandler(config_entry)
     
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_POWER.seconds),
+                    ): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=300)
+                    )
+                }
+            ),
+        ) 
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
@@ -148,3 +181,4 @@ class CannotConnect(HomeAssistantError):
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+

--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -44,16 +44,16 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     if device is None:
         raise CannotConnect
     
-    
+    device_id = device.serial_number[0:4]
     # Return info that you want to store in the config entry.
     if isinstance(device, SessyBattery):
-        return {"title": "Sessy Battery"}
+        return {"title": f"Sessy Battery {device_id}"}
     elif isinstance(device, SessyP1Meter):
         return {"title": "Sessy P1"}
     elif isinstance(device, SessyCTMeter):
         return {"title": "Sessy CT"}
     else:
-        return {"title": "Sessy"}
+        return {"title": f"Sessy {device_id}"}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import device_registry as dr
 
-from sessypy.devices import get_sessy_device, SessyBattery, SessyP1Meter
+from sessypy.devices import get_sessy_device, SessyBattery, SessyP1Meter, SessyCTMeter
 from sessypy.util import SessyConnectionException, SessyLoginException
 
 from .const import DEFAULT_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_POWER, DOMAIN
@@ -50,6 +50,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         return {"title": "Sessy Battery"}
     elif isinstance(device, SessyP1Meter):
         return {"title": "Sessy P1"}
+    elif isinstance(device, SessyCTMeter):
+        return {"title": "Sessy CT"}
     else:
         return {"title": "Sessy"}
 

--- a/custom_components/sessy/const.py
+++ b/custom_components/sessy/const.py
@@ -1,10 +1,11 @@
 from datetime import timedelta
 from sessypy.api import SessyApiCommand
+from sessypy.const import SessyOtaState
 
 DOMAIN = "sessy"
 
 # Default scan interval for all entities except power related
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 
 # Default scan interval for power related entities, overridden by scan_interval option config flow
 DEFAULT_SCAN_INTERVAL_POWER = timedelta(seconds=5)
@@ -25,5 +26,6 @@ TIME_TRACKER_POWER = "time_tracker_power"
 SESSY_CACHE = "sessy_cache"
 SESSY_CACHE_TRACKERS = "sessy_cache_trackers"
 SESSY_CACHE_TRIGGERS = "sessy_cache_triggers"
+SESSY_CACHE_INTERVAL = "sessy_cache_interval"
 
 ENTITY_ERROR_THRESHOLD = 5

--- a/custom_components/sessy/const.py
+++ b/custom_components/sessy/const.py
@@ -2,8 +2,15 @@ from datetime import timedelta
 from sessypy.api import SessyApiCommand
 
 DOMAIN = "sessy"
+
+# Default scan interval for all entities except power related
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
-SCAN_INTERVAL_POWER = timedelta(seconds=10)
+
+# Default scan interval for power related entities, overridden by scan_interval option config flow
+DEFAULT_SCAN_INTERVAL_POWER = timedelta(seconds=5)
+
+# Static scan intervals
+SCAN_INTERVAL_POWER = timedelta(seconds=5)
 SCAN_INTERVAL_OTA = timedelta(seconds=15)
 SCAN_INTERVAL_OTA_CHECK = timedelta(hours=6)
 

--- a/custom_components/sessy/number.py
+++ b/custom_components/sessy/number.py
@@ -29,7 +29,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     numbers = []
 
     if isinstance(device, SessyBattery):
-        await add_cache_command(hass, config_entry, SessyApiCommand.POWER_STATUS, SCAN_INTERVAL_POWER)
         numbers.append(
             SessyNumber(hass, config_entry, "Power Setpoint",
                         SessyApiCommand.POWER_STATUS, "sessy.power_setpoint",
@@ -38,7 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             
         )
 
-        await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_SETTINGS, DEFAULT_SCAN_INTERVAL)
         async def partial_update_settings(key,value):
             settings: dict = await device.get_system_settings()
             settings[key] = value

--- a/custom_components/sessy/select.py
+++ b/custom_components/sessy/select.py
@@ -26,7 +26,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     selects = []
 
     if isinstance(device, SessyBattery):
-        await add_cache_command(hass, config_entry, SessyApiCommand.POWER_STRATEGY, DEFAULT_SCAN_INTERVAL)
         selects.append(
             SessySelect(hass, config_entry, "Power Strategy",
                         SessyApiCommand.POWER_STRATEGY,"strategy",

--- a/custom_components/sessy/sensor.py
+++ b/custom_components/sessy/sensor.py
@@ -30,14 +30,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     device = hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE]
     sensors = []
 
-    await add_cache_command(hass, config_entry, SessyApiCommand.NETWORK_STATUS)
     sensors.append(
         SessySensor(hass, config_entry, "WiFi RSSI",
                     SessyApiCommand.NETWORK_STATUS, "wifi_sta.rssi",
                     SensorDeviceClass.SIGNAL_STRENGTH, SensorStateClass.MEASUREMENT, SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
                     entity_category=EntityCategory.DIAGNOSTIC)
     )
-    await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_INFO, DEFAULT_SCAN_INTERVAL)
+
     for memory_type in ("internal","external"):
         sensors.append(
             SessySensor(hass, config_entry, f"{ memory_type.title() } Memory Available",
@@ -48,7 +47,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         )
 
     if isinstance(device, SessyBattery):
-        await add_cache_command(hass, config_entry, SessyApiCommand.POWER_STATUS, SCAN_INTERVAL_POWER)
         sensors.append(
             SessySensor(hass, config_entry, "System State",
                         SessyApiCommand.POWER_STATUS, "sessy.system_state",
@@ -111,7 +109,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
 
     elif isinstance(device, SessyP1Meter):
-        await add_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, SCAN_INTERVAL_POWER)
         sensors.append(
             SessySensor(hass, config_entry, "P1 Power",
                         SessyApiCommand.P1_DETAILS, "total_power",
@@ -143,7 +140,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             )
 
     elif isinstance(device, SessyCTMeter):
-        await add_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, SCAN_INTERVAL_POWER)
         sensors.append(
             SessySensor(hass, config_entry, "Total Power",
                         SessyApiCommand.P1_DETAILS, "total_power",

--- a/custom_components/sessy/strings.json
+++ b/custom_components/sessy/strings.json
@@ -23,6 +23,16 @@
     },
     "flow_title": "{name}"
   },
+  "options": {
+    "step": {
+      "init": {
+        "description": "How often to poll Sessy for new data",
+        "data":{
+          "scan_interval": "Scan interval"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor":{
       "battery_system_state":{

--- a/custom_components/sessy/translations/en.json
+++ b/custom_components/sessy/translations/en.json
@@ -23,6 +23,16 @@
     },
     "flow_title": "{name}"
   },
+  "options": {
+    "step": {
+      "init": {
+        "description": "How often to poll Sessy for new data",
+        "data":{
+          "scan_interval": "Scan interval"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor":{
       "battery_system_state":{

--- a/custom_components/sessy/translations/nl.json
+++ b/custom_components/sessy/translations/nl.json
@@ -23,6 +23,16 @@
     },
     "flow_title": "{name}"
   },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Hoe vaak nieuwe data wordt opgevraagd bij Sessy",
+        "data":{
+          "scan_interval": "Scan interval"
+        }
+      }
+    }
+  },
   "entity": {
     "sensor":{
       "battery_system_state":{

--- a/custom_components/sessy/update.py
+++ b/custom_components/sessy/update.py
@@ -28,8 +28,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     device = hass.data[DOMAIN][config_entry.entry_id][SESSY_DEVICE]
     updates = []
 
-    await add_cache_command(hass, config_entry, SessyApiCommand.OTA_CHECK, SCAN_INTERVAL_OTA_CHECK)
-    await add_cache_command(hass, config_entry, SessyApiCommand.OTA_STATUS, SCAN_INTERVAL_OTA)
 
     # TODO Disabled by default for now, remove later
     if isinstance(device, SessyBattery):

--- a/custom_components/sessy/update.py
+++ b/custom_components/sessy/update.py
@@ -30,40 +30,49 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
     await add_cache_command(hass, config_entry, SessyApiCommand.OTA_CHECK, SCAN_INTERVAL_OTA_CHECK)
     await add_cache_command(hass, config_entry, SessyApiCommand.OTA_STATUS, SCAN_INTERVAL_OTA)
-    
+
+    # TODO Disabled by default for now, remove later
     if isinstance(device, SessyBattery):
         updates.append(
-            SessyUpdate(hass, config_entry, "Battery Dongle", SessyOtaTarget.SELF)
+            SessyUpdate(hass, config_entry, "Battery Dongle", SessyOtaTarget.SELF, enabled_default=False)
         )
         updates.append(
-            SessyUpdate(hass, config_entry, "Battery", SessyOtaTarget.SERIAL)
+            SessyUpdate(hass, config_entry, "Battery", SessyOtaTarget.SERIAL, enabled_default=False)
 		)
-        updates.append(
-            SessyUpdate(hass, config_entry, "All", SessyOtaTarget.ALL)  # available as of version 1.5.1
-		)
-
+    
     elif isinstance(device, SessyP1Meter) or isinstance(device, SessyCTMeter):
         updates.append(
-            SessyUpdate(hass, config_entry, "Dongle", SessyOtaTarget.SELF)
+            SessyUpdate(hass, config_entry, "Dongle", SessyOtaTarget.SELF, enabled_default=False)
         )
+
+    # Treat Sessy Dongle and serial device (AC board) as one unit
+    updates.append(
+        SessyUpdate(hass, config_entry, "Firmware", SessyOtaTarget.SELF, action_target=SessyOtaTarget.ALL)
+    )
 
     async_add_entities(updates)
     
 class SessyUpdate(SessyEntity, UpdateEntity):
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, name: str,
-                 update_target: SessyOtaTarget, transform_function: function = None
-                 ):
+                 cache_target: SessyOtaTarget, action_target: SessyOtaTarget = None,
+                 transform_function: function = None, enabled_default: bool = True):
         
         cache_command = SessyApiCommand.OTA_STATUS
-        cache_key = update_target.name.lower()
+        cache_key = cache_target.name.lower()
         super().__init__(hass=hass, config_entry=config_entry, name=name, 
                        cache_command=cache_command, cache_key=cache_key, 
                        transform_function=transform_function)
         
+        self._attr_entity_registry_enabled_default = enabled_default
         self._attr_device_class = UpdateDeviceClass.FIRMWARE
         self._attr_supported_features = UpdateEntityFeature.INSTALL + UpdateEntityFeature.PROGRESS
 
-        self.update_target = update_target
+        self.cache_target = cache_target
+        if action_target:
+            self.action_target = action_target
+        else:
+            self.action_target = cache_target
+
         self.cache_value = dict()
        
     def update_from_cache(self):
@@ -79,7 +88,7 @@ class SessyUpdate(SessyEntity, UpdateEntity):
         self._attr_installed_version = self.cache_value.get("installed_firmware", dict()).get("version", None)
 
         # Write new firmware version to device registry
-        if self.update_target == SessyOtaTarget.SELF and last_installed_version != self._attr_installed_version:
+        if self.cache_target == SessyOtaTarget.SELF and last_installed_version != self._attr_installed_version:
             try:
                 device_registry = dr.async_get(self.hass)
                 device = device_registry.async_get_device(self.device_info[ATTR_IDENTIFIERS])
@@ -108,7 +117,7 @@ class SessyUpdate(SessyEntity, UpdateEntity):
     async def async_install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         device: SessyDevice = self.hass.data[DOMAIN][self.config_entry.entry_id][SESSY_DEVICE]
         try:
-            await device.install_ota(self.update_target)
+            await device.install_ota(self.action_target)
         except SessyNotSupportedException as e:
             raise HomeAssistantError(f"Starting update for {self.name} failed: Not supported by device") from e
             
@@ -116,6 +125,6 @@ class SessyUpdate(SessyEntity, UpdateEntity):
             raise HomeAssistantError(f"Starting update for {self.name} failed: Connection error") from e
 
         except Exception as e:
-            raise HomeAssistantError(f"Setting value for {self.name} failed: {e.__class__}") from e
+            raise HomeAssistantError(f"Starting update for {self.name} failed: {e.__class__}") from e
         
         await trigger_cache_update(self.hass, self.config_entry, self.cache_command)

--- a/custom_components/sessy/util.py
+++ b/custom_components/sessy/util.py
@@ -3,6 +3,7 @@ from datetime import datetime, time, timedelta
 from enum import Enum
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_SCAN_INTERVAL
 
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
@@ -14,7 +15,44 @@ from sessypy.devices import SessyDevice, SessyBattery, SessyP1Meter, SessyCTMete
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-from .const import DOMAIN, SESSY_CACHE, SESSY_CACHE_TRACKERS, SESSY_CACHE_TRIGGERS, SESSY_DEVICE, UPDATE_TOPIC, DEFAULT_SCAN_INTERVAL
+from .const import DEFAULT_SCAN_INTERVAL_POWER, DOMAIN, SCAN_INTERVAL_OTA, SCAN_INTERVAL_OTA_CHECK, SCAN_INTERVAL_POWER, SESSY_CACHE, SESSY_CACHE_INTERVAL, SESSY_CACHE_TRACKERS, SESSY_CACHE_TRIGGERS, SESSY_DEVICE, UPDATE_TOPIC, DEFAULT_SCAN_INTERVAL
+
+async def setup_cache(hass: HomeAssistant, config_entry: ConfigEntry):
+    hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE] = dict()
+    hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_TRACKERS] = dict()
+    hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_TRIGGERS] = dict()
+    hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_INTERVAL] = dict()
+
+async def setup_cache_commands(hass, config_entry: ConfigEntry, device: SessyDevice, setup=True):
+
+    # Skip static update intervals if updating from config flow handler
+    if setup:
+        # Sessy will not check for updates automatically, poll at intervals
+        await add_cache_command(hass, config_entry, SessyApiCommand.OTA_CHECK, SCAN_INTERVAL_OTA_CHECK)
+
+        # TODO Update more quickly 
+        await add_cache_command(hass, config_entry, SessyApiCommand.OTA_STATUS, DEFAULT_SCAN_INTERVAL)
+        await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_INFO, DEFAULT_SCAN_INTERVAL)
+        await add_cache_command(hass, config_entry, SessyApiCommand.NETWORK_STATUS)
+
+        if isinstance(device, SessyBattery):
+            await add_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_SETTINGS, DEFAULT_SCAN_INTERVAL)
+            await add_cache_command(hass, config_entry, SessyApiCommand.POWER_STRATEGY, DEFAULT_SCAN_INTERVAL)
+
+
+    # Get power scan interval from options flow
+    scan_power_seconds = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_POWER.seconds)
+    scan_interval_power = timedelta(seconds = scan_power_seconds)
+
+    if isinstance(device, SessyBattery):
+        await add_cache_command(hass, config_entry, SessyApiCommand.POWER_STATUS, scan_interval_power)
+
+    elif isinstance(device, SessyP1Meter):
+        await add_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, scan_interval_power)
+
+    elif isinstance(device, SessyCTMeter):
+        await add_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, scan_interval_power)
+        
 
 async def add_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, command: SessyApiCommand, interval: timedelta = DEFAULT_SCAN_INTERVAL):
     if not command in hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE]:
@@ -40,6 +78,7 @@ async def add_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, comm
 
     hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_TRACKERS][command] = async_track_time_interval(hass, update, interval)
     hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_TRIGGERS][command] = update
+    hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_INTERVAL][command] = interval
     await update()
 
 async def clear_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, command: SessyApiCommand = None):
@@ -53,6 +92,12 @@ async def clear_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, co
         tracker = trackers[command]
         tracker()
 
+async def get_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, command: SessyApiCommand, key: str):
+    cache: dict = hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE]
+    if key:
+        return cache.get(key)
+    else:
+        return cache
 
 async def trigger_cache_update(hass: HomeAssistant, config_entry: ConfigEntry, command: SessyApiCommand):
     update = hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE_TRIGGERS][command]


### PR DESCRIPTION
- Add SessyOtaTarget.ALL: Updates both self and serial, effectively updating both the dongle and AC board in Sessy Battery's.
- Disable independent OTA entities by default. Current installations will keep the old entities, but can disable them.
- Move cache setup to utils, away from platform code
- Add option flow for updating the scan interval for power-related sensors.
- Update default scan interval for power entities to 5 seconds (minimum)
- Add device ID (first 4 characters of serial number) to config flow title