### PR TITLE
Add Sessy FW 1.5.2+ features

### DIFF
--- a/custom_components/sessy/button.py
+++ b/custom_components/sessy/button.py
@@ -28,6 +28,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                     device_class=ButtonDeviceClass.RESTART, entity_category=EntityCategory.DIAGNOSTIC
                     )
     )
+    buttons.append(
+        SessyButton(hass, config_entry, "Check for updates",
+                    SessyApiCommand.OTA_STATUS, 'status', device.check_ota,
+                    entity_category=EntityCategory.DIAGNOSTIC
+                    )
+    )
 
     async_add_entities(buttons)
     

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -10,7 +10,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
-  "requirements": ["sessypy==0.1.3"],
+  "requirements": ["sessypy==0.1.4"],
   "version": "0.5.1",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.1.3"],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]

--- a/custom_components/sessy/number.py
+++ b/custom_components/sessy/number.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 
 from sessypy.const import SessyApiCommand
-from sessypy.devices import SessyBattery, SessyDevice
+from sessypy.devices import SessyBattery, SessyDevice, SessyMeter
 from sessypy.util import SessyNotSupportedException, SessyConnectionException
 
 
@@ -77,6 +77,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         except Exception as e:
             _LOGGER.warning(f"Error setting up noise control: {e}")
 
+    elif isinstance(device, SessyMeter):
+         numbers.append(
+            SessyNumber(hass, config_entry, "Grid Target",
+                        SessyApiCommand.METER_GRID_TARGET, "grid_target",
+                        SessyApiCommand.METER_GRID_TARGET, "grid_target",
+                        NumberDeviceClass.POWER, UnitOfPower.WATT, -20000, 20000,
+                        entity_category=EntityCategory.CONFIG)
+            
+        )
 
     async_add_entities(numbers)
     

--- a/custom_components/sessy/util.py
+++ b/custom_components/sessy/util.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from sessypy.const import SessyApiCommand
-from sessypy.devices import SessyDevice, SessyBattery, SessyP1Meter, SessyCTMeter
+from sessypy.devices import SessyDevice, SessyBattery, SessyMeter, SessyP1Meter, SessyCTMeter
 
 import logging
 _LOGGER = logging.getLogger(__name__)
@@ -50,8 +50,11 @@ async def setup_cache_commands(hass, config_entry: ConfigEntry, device: SessyDev
         await setup_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, scan_interval_power)
 
     elif isinstance(device, SessyCTMeter):
-        await setup_cache_command(hass, config_entry, SessyApiCommand.P1_DETAILS, scan_interval_power)
-        
+        await setup_cache_command(hass, config_entry, SessyApiCommand.CT_DETAILS, scan_interval_power)
+    
+    if isinstance(device, SessyMeter):
+        await setup_cache_command(hass, config_entry, SessyApiCommand.METER_GRID_TARGET)
+
 async def setup_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, command: SessyApiCommand, interval: timedelta = DEFAULT_SCAN_INTERVAL):
     update = set_cache_command(hass, config_entry, command, interval)
     await update()


### PR DESCRIPTION
Breaking change: Deprecates Sessy FW < 1.5.2
- Add grid target to Sessy Meter devices
- Add more sensors to P1/CT devices
- Add 'Check for updates' button