### PR TITLE
Set update entity feature flags and update SessyPy

### DIFF
--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -10,7 +10,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
-  "requirements": ["sessypy==0.1.6"],
+  "requirements": ["sessypy==0.1.7"],
   "version": "0.5.6",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.1.6"],
-  "version": "0.5.5",
+  "version": "0.5.6",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]

--- a/custom_components/sessy/update.py
+++ b/custom_components/sessy/update.py
@@ -62,7 +62,7 @@ class SessyUpdate(SessyEntity, UpdateEntity):
         
         self._attr_entity_registry_enabled_default = enabled_default
         self._attr_device_class = UpdateDeviceClass.FIRMWARE
-        self._attr_supported_features = UpdateEntityFeature.INSTALL + UpdateEntityFeature.PROGRESS
+        self._attr_supported_features = UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
 
         self.cache_target = cache_target
         if action_target:


### PR DESCRIPTION
- Update entity feature flags for Home Assistant 2024.02 compatibility
- Bump SessyPy to 0.1.7 for Python 3.12 compatibility