### PR TITLE
Change English NOM translation

### DIFF
--- a/custom_components/sessy/translations/en.json
+++ b/custom_components/sessy/translations/en.json
@@ -68,7 +68,7 @@
       "battery_strategy":{
         "state":{
           "api": "API",
-          "nom": "Null on the meter",
+          "nom": "Net zero",
           "roi": "Dynamic",
           "idle": "Idle",
           "eco": "Eco",


### PR DESCRIPTION
Null on the meter is bloomcoal English for nul op de meter.  A literal translation would be "zero on the meter". According to google, "microgrid" or "off-grid" are commonly used terms to indicate an energy management strategy with minimal dependency on the grid, but I'm not a fan of the suggestion of being a true stand alone strategy. The term "net zero" is not specific to energy management but I think it's an excellent descriptive and sintactically correct term to use here.

Feel free to decline the pull request if you don't like it. It's just a suggestion.