### PR TITLE
Add logging for api errors

### DIFF
--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.1.12"],
-  "version": "0.7.1",
+  "version": "0.7.2",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]

--- a/custom_components/sessy/number.py
+++ b/custom_components/sessy/number.py
@@ -64,7 +64,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         # Firmware or hardware-revision specific settings
         try:
             settings: dict = get_cache_command(hass, config_entry, SessyApiCommand.SYSTEM_SETTINGS)
-        
+            if "error" in settings:
+                _LOGGER.warning(f"Sessy settings api returned an error:\n{ settings.get("error") }\nSome entities might not work until settings are saved in the Sessy portal or web UI.")
+
             # Noise controls
             if settings.get("disable_noise_level", True) == False:
                 numbers.append(
@@ -99,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
                     
                 )
         except Exception as e:
-            _LOGGER.warning(f"Error setting firmware specific settings: {e}")
+            _LOGGER.warning(f"Error setting up firmware specific settings: {e}\n{settings}")
         
 
     elif isinstance(device, SessyMeter):

--- a/custom_components/sessy/util.py
+++ b/custom_components/sessy/util.py
@@ -76,8 +76,10 @@ def set_cache_command(hass: HomeAssistant, config_entry: ConfigEntry, command: S
         cache: dict = hass.data[DOMAIN][config_entry.entry_id][SESSY_CACHE]
 
         try:
-            result = await device.api.get(command)
+            result: dict = await device.api.get(command)
             cache[command] = result
+            if "error" in result:
+                _LOGGER.debug(f"Sessy api returned an error while updating cache for {command}: {result.get("error")}")
         except Exception as e:
             result = None
             cache[command] = None


### PR DESCRIPTION
Adds debug log if any api call returns an error field
Adds warning log if settings api returns an error field during setup

Closes #97 
