### PR TITLE
Add SessyPy package to loggers

### DIFF
--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "requirements": ["sessypy==0.2.1"],
-  "version": "0.8.4",
+  "version": "0.8.5",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}
   ]

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -10,6 +10,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
+  "loggers": ["sessypy"],
   "requirements": ["sessypy==0.2.1"],
   "version": "0.8.5",
   "zeroconf":[


### PR DESCRIPTION
Enables debug logging for upstream Python package (SessyPy ) when Home Assistant debug mode is enabled