### PR TITLE
Move to Dynamic Schedule v2 API

### DIFF
--- a/custom_components/sessy/coordinator.py
+++ b/custom_components/sessy/coordinator.py
@@ -54,7 +54,9 @@ async def setup_coordinators(hass, config_entry: SessyConfigEntry, device: Sessy
                 SessyCoordinator(hass, config_entry, device.get_dynamic_schedule, SCAN_INTERVAL_SCHEDULE)
             )
         except SessyNotSupportedException as e:
+            _LOGGER.warning(f"{ device.name } is not using the latest dynamic schedule API, falling back to legacy schedule sensors. Update Sessy to firmware 1.9.2 or later to use the new dynamic schedule API.") 
             try:
+                # Fallback to legacy dynamic schedule if the new one is not supported
                 await device.get_dynamic_schedule_legacy()
                 coordinators.append(
                     SessyCoordinator(hass, config_entry, device.get_dynamic_schedule_legacy, SCAN_INTERVAL_SCHEDULE)

--- a/custom_components/sessy/coordinator.py
+++ b/custom_components/sessy/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 from sessypy.devices import SessyBattery, SessyCTMeter, SessyDevice, SessyMeter, SessyP1Meter
-from sessypy.util import SessyException, SessyLoginException
+from sessypy.util import SessyException, SessyLoginException, SessyNotSupportedException
 
 from .const import COORDINATOR_RETRIES, COORDINATOR_RETRY_DELAY, COORDINATOR_TIMEOUT, DEFAULT_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL_POWER, ENTITY_ERROR_THRESHOLD, SCAN_INTERVAL_OTA_CHECK, SCAN_INTERVAL_SCHEDULE
 from .models import SessyConfigEntry
@@ -44,11 +44,26 @@ async def setup_coordinators(hass, config_entry: SessyConfigEntry, device: Sessy
 
     if isinstance(device, SessyBattery):
         coordinators.extend([
-            SessyCoordinator(hass, config_entry, device.get_dynamic_schedule, SCAN_INTERVAL_SCHEDULE),
             SessyCoordinator(hass, config_entry, device.get_power_status, scan_interval_power),
             SessyCoordinator(hass, config_entry, device.get_power_strategy),
             SessyCoordinator(hass, config_entry, device.get_system_settings),
         ])
+        try:
+            await device.get_dynamic_schedule()
+            coordinators.append(
+                SessyCoordinator(hass, config_entry, device.get_dynamic_schedule, SCAN_INTERVAL_SCHEDULE)
+            )
+        except SessyNotSupportedException as e:
+            try:
+                await device.get_dynamic_schedule_legacy()
+                coordinators.append(
+                    SessyCoordinator(hass, config_entry, device.get_dynamic_schedule_legacy, SCAN_INTERVAL_SCHEDULE)
+                )
+            except SessyNotSupportedException as e:
+                _LOGGER.warning(f"Dynamic schedule not supported by Sessy device {device.serial_number}. Error: {e}")
+        except Exception as e:
+            _LOGGER.error(f"Error while fetching dynamic schedule for Sessy device {device.serial_number}. Error: {e}")
+            
 
 
     elif isinstance(device, SessyP1Meter):

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "loggers": ["sessypy"],
-  "requirements": ["sessypy==0.2.1"],
+  "requirements": ["sessypy==0.2.2"],
   "version": "0.8.6",
   "zeroconf":[
     {"type":"_http._tcp.local.","name":"sessy-*"}

--- a/custom_components/sessy/sensor.py
+++ b/custom_components/sessy/sensor.py
@@ -92,7 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SessyConfigEntry,
                 # Fallback to legacy schedule if dynamic schedule is not supported
                 # TODO remove this when legacy schedule is no longer supported
 
-                _LOGGER.warning(f"{ device.name } is not using the latest dynamic schedule API, falling back to legacy schedule sensors. Update Sessy to firmware 1.9.2 or later to use the new dynamic schedule API.")
                 dynamic_schedule_coordinator: SessyCoordinator = coordinators.get(device.get_dynamic_schedule_legacy, None)
                 if dynamic_schedule_coordinator != None:
                     dynamic_schedule: dict = dynamic_schedule_coordinator.raw_data
@@ -114,7 +113,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SessyConfigEntry,
                                         schedule_key="price", transform_function=divide_by_hundred_thousand            
                             )
                         )
-
 
         except Exception as e:
             _LOGGER.warning(f"Error setting up schedule sensors: {e}")


### PR DESCRIPTION
Sessy 1.9.2 introduces the Dynamic Schedule API version 2, which supports schedules by timestamp.
A fallback mechanism is in place for the API version 1 for as long as it is officially supported.

Full schedules are now available under an attribute on a schedule sensor instead of a date attribute.