### PR TITLE
Format IP address as string before passing to config flow

### DIFF
--- a/custom_components/sessy/config_flow.py
+++ b/custom_components/sessy/config_flow.py
@@ -65,8 +65,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    hostname = None
-    username = None
+    hostname: str = None
+    username: str = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -192,7 +192,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._name = local_name.removesuffix(".local")
 
             # Update the autofill information
-            self.hostname = ip_address
+            self.hostname = ip_address.compressed
             self.username = serial_number
         except Exception:
             return self.async_abort(reason="discovery_error")

--- a/custom_components/sessy/manifest.json
+++ b/custom_components/sessy/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/PimDoos/ha-sessy/issues",
   "loggers": ["sessypy"],
   "requirements": ["sessypy==0.2.6"],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "zeroconf": [{ "type": "_http._tcp.local.", "name": "sessy-*" }]
 }


### PR DESCRIPTION
Fix #179 

While in the zeroconf config step, the IP address was passed through as-is, while the config flow needs a string.
Patched to use ip_address.compressed string property as hostname default.
Also added type hints to hostname and username variables.